### PR TITLE
Party機能（募集単位）を追加しチーム分け制約を実装

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"os"
 	"os/signal"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -26,6 +27,7 @@ type Bot struct {
 	pendingRestartsMu    sync.RWMutex
 	pendingMatchRestarts map[string]pendingMatchRestart
 	pendingRegistrations map[string]pendingRegEntry
+	pendingPartyMembers  map[string][]string
 	testDummies          map[string]map[string]model.PlayerInfo
 	now                  func() time.Time
 	readyOnce            sync.Once
@@ -89,6 +91,7 @@ func New(dbPath string) (*Bot, error) {
 		recruitments:         make(map[string]*model.Recruitment),
 		pendingMatchRestarts: make(map[string]pendingMatchRestart),
 		pendingRegistrations: make(map[string]pendingRegEntry),
+		pendingPartyMembers:  make(map[string][]string),
 		testDummies:          make(map[string]map[string]model.PlayerInfo),
 		now:                  time.Now,
 	}, nil
@@ -194,6 +197,16 @@ func (b *Bot) onInteractionCreate(s *discordgo.Session, i *discordgo.Interaction
 			b.handleAssign(s, i)
 		case customID == "cancel":
 			b.handleCancel(s, i)
+		case customID == "party_open":
+			b.handlePartyOpen(s, i)
+		case customID == "party_members_select":
+			b.handlePartyMemberSelect(s, i)
+		case customID == "party_save":
+			b.handlePartySave(s, i)
+		case customID == "party_clear":
+			b.handlePartyClear(s, i)
+		case customID == "party_close":
+			b.handlePartyClose(s, i)
 		case strings.HasPrefix(customID, "match_restart_confirm:"):
 			b.handleMatchRestartConfirm(s, i)
 		case strings.HasPrefix(customID, "match_restart_cancel:"):
@@ -606,6 +619,7 @@ func (b *Bot) handleCancelEntry(s *discordgo.Session, i *discordgo.InteractionCr
 	}
 
 	userID, _ := interactionUser(i)
+	hostID, hasParty := r.FindPartyHostOf(userID)
 	if !r.RemoveEntry(userID) {
 		if err := b.respondEphemeralText(s, i, "エントリーしていません"); err != nil {
 			log.Printf("failed to respond missing entry on cancel: %v", err)
@@ -624,6 +638,104 @@ func (b *Bot) handleCancelEntry(s *discordgo.Session, i *discordgo.InteractionCr
 	if err := b.ackInteraction(s, i); err != nil {
 		log.Printf("failed to respond cancel entry success: %v", err)
 	}
+	if hasParty {
+		_, _ = s.FollowupMessageCreate(i.Interaction, true, &discordgo.WebhookParams{
+			Content: "⚠️ Partyメンバーが取り消したため、Party全員のエントリーを外してPartyを解除しました。",
+			Flags:   discordgo.MessageFlagsEphemeral,
+		})
+		delete(b.pendingPartyMembers, hostID)
+	}
+}
+
+func (b *Bot) handlePartyOpen(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	r, ok := b.getRecruitment(i.ChannelID)
+	if !ok || !r.IsOpen {
+		_ = b.respondEphemeralText(s, i, "募集終了後はParty設定できません")
+		return
+	}
+	userID, _ := interactionUser(i)
+	if !r.IsEntered(userID) {
+		_ = b.respondEphemeralText(s, i, "先にエントリーしてください")
+		return
+	}
+	selected := b.currentPartyMemberSelection(r, userID)
+	b.pendingPartyMembers[i.ChannelID+":"+userID] = selected
+	_ = b.respondPartyMessage(s, i, r, userID, "", false)
+}
+
+func (b *Bot) handlePartyMemberSelect(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	r, ok := b.getRecruitment(i.ChannelID)
+	if !ok || !r.IsOpen {
+		_ = b.updateComponentWithText(s, i, "募集終了後はParty設定できません")
+		return
+	}
+	userID, _ := interactionUser(i)
+	if !r.IsEntered(userID) {
+		_ = b.updateComponentWithText(s, i, "先にエントリーしてください")
+		return
+	}
+	selected := append([]string(nil), i.MessageComponentData().Values...)
+	b.pendingPartyMembers[i.ChannelID+":"+userID] = selected
+	_ = b.respondPartyMessage(s, i, r, userID, "", true)
+}
+
+func (b *Bot) handlePartySave(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	r, ok := b.getRecruitment(i.ChannelID)
+	if !ok || !r.IsOpen {
+		_ = b.updateComponentWithText(s, i, "募集終了後はParty設定できません")
+		return
+	}
+	userID, _ := interactionUser(i)
+	if !r.IsEntered(userID) {
+		_ = b.updateComponentWithText(s, i, "先にエントリーしてください")
+		return
+	}
+
+	selected := b.currentPartyMemberSelection(r, userID)
+	if pending, ok := b.pendingPartyMembers[i.ChannelID+":"+userID]; ok {
+		selected = append([]string(nil), pending...)
+	}
+	if len(selected)+1 > 5 {
+		_ = b.respondPartyMessage(s, i, r, userID, "❌ Partyは最大5人までです", true)
+		return
+	}
+
+	validCandidates := b.partyCandidateSet(r, userID)
+	for _, id := range selected {
+		if strings.HasPrefix(id, "dummy-") {
+			_ = b.respondPartyMessage(s, i, r, userID, "❌ ダミープレイヤーはPartyに入れられません", true)
+			return
+		}
+		if _, ok := validCandidates[id]; !ok {
+			_ = b.respondPartyMessage(s, i, r, userID, "❌ 選択相手がすでに別Partyに所属しているか、参加者ではありません", true)
+			return
+		}
+	}
+	r.SetParty(userID, selected)
+	delete(b.pendingPartyMembers, i.ChannelID+":"+userID)
+	if err := b.updateRecruitEmbed(s, r, false); err != nil {
+		log.Printf("failed to update recruit embed after party save: %v", err)
+	}
+	_ = b.respondPartyMessage(s, i, r, userID, "✅ Partyを保存しました", true)
+}
+
+func (b *Bot) handlePartyClear(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	r, ok := b.getRecruitment(i.ChannelID)
+	if !ok || !r.IsOpen {
+		_ = b.updateComponentWithText(s, i, "募集終了後はParty設定できません")
+		return
+	}
+	userID, _ := interactionUser(i)
+	r.ClearParty(userID)
+	delete(b.pendingPartyMembers, i.ChannelID+":"+userID)
+	if err := b.updateRecruitEmbed(s, r, false); err != nil {
+		log.Printf("failed to update recruit embed after party clear: %v", err)
+	}
+	_ = b.respondPartyMessage(s, i, r, userID, "✅ Partyを解除しました", true)
+}
+
+func (b *Bot) handlePartyClose(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	_ = b.updateComponentWithText(s, i, "Party設定を閉じました。")
 }
 
 func (b *Bot) handleAssign(s *discordgo.Session, i *discordgo.InteractionCreate) {
@@ -971,13 +1083,64 @@ func recruitParticipantList(r *model.Recruitment) string {
 		return "（なし）"
 	}
 
-	users := make([]string, 0, len(r.Entries))
+	type partyInfo struct {
+		label   string
+		isHost  bool
+		partyNo int
+	}
+	partyByUser := map[string]partyInfo{}
+	partyHosts := make([]string, 0, len(r.Parties))
+	for hostID := range r.Parties {
+		partyHosts = append(partyHosts, hostID)
+	}
+	sort.Strings(partyHosts)
+	for idx, hostID := range partyHosts {
+		partyNo := idx + 1
+		partyByUser[hostID] = partyInfo{label: fmt.Sprintf("Party%d", partyNo), isHost: true, partyNo: partyNo}
+		for _, memberID := range r.Parties[hostID] {
+			partyByUser[memberID] = partyInfo{label: fmt.Sprintf("Party%d", partyNo), isHost: false, partyNo: partyNo}
+		}
+	}
+
+	ordered := make([]model.Entry, 0, len(r.Entries))
+	for _, hostID := range partyHosts {
+		for _, e := range r.Entries {
+			if e.UserID == hostID {
+				ordered = append(ordered, e)
+				break
+			}
+		}
+		for _, memberID := range r.Parties[hostID] {
+			for _, e := range r.Entries {
+				if e.UserID == memberID {
+					ordered = append(ordered, e)
+					break
+				}
+			}
+		}
+	}
 	for _, e := range r.Entries {
-		if strings.HasPrefix(e.UserID, "dummy-") {
-			users = append(users, e.Name)
+		if _, ok := partyByUser[e.UserID]; ok {
 			continue
 		}
-		users = append(users, "<@"+e.UserID+">")
+		ordered = append(ordered, e)
+	}
+
+	users := make([]string, 0, len(ordered))
+	for _, e := range ordered {
+		name := "<@" + e.UserID + ">"
+		if strings.HasPrefix(e.UserID, "dummy-") {
+			name = e.Name
+		}
+		if info, ok := partyByUser[e.UserID]; ok {
+			role := "メンバー"
+			if info.isHost {
+				role = "ホスト"
+			}
+			users = append(users, fmt.Sprintf("%s - %s %s", name, info.label, role))
+			continue
+		}
+		users = append(users, name)
 	}
 	return strings.Join(users, "\n")
 }
@@ -1006,6 +1169,12 @@ func (b *Bot) buildRecruitComponents(r *model.Recruitment, disabled bool) []disc
 					Style:    discordgo.SecondaryButton,
 					Disabled: disabled,
 				},
+				discordgo.Button{
+					Label:    "👥 Party設定",
+					CustomID: "party_open",
+					Style:    discordgo.SecondaryButton,
+					Disabled: disabled,
+				},
 			},
 		},
 		discordgo.ActionsRow{
@@ -1025,6 +1194,131 @@ func (b *Bot) buildRecruitComponents(r *model.Recruitment, disabled bool) []disc
 			},
 		},
 	}
+}
+
+func (b *Bot) partyCandidateSet(r *model.Recruitment, hostID string) map[string]struct{} {
+	candidates := map[string]struct{}{}
+	if r == nil {
+		return candidates
+	}
+	for _, e := range r.Entries {
+		if e.UserID == hostID || strings.HasPrefix(e.UserID, "dummy-") {
+			continue
+		}
+		partyHost, inParty := r.FindPartyHostOf(e.UserID)
+		if inParty && partyHost != hostID {
+			continue
+		}
+		candidates[e.UserID] = struct{}{}
+	}
+	return candidates
+}
+
+func (b *Bot) currentPartyMemberSelection(r *model.Recruitment, hostID string) []string {
+	if r == nil || r.Parties == nil {
+		return []string{}
+	}
+	members := r.Parties[hostID]
+	return append([]string(nil), members...)
+}
+
+func (b *Bot) partyStateText(r *model.Recruitment, hostID string) string {
+	members := r.Parties[hostID]
+	if len(members) == 0 {
+		return "現在のParty設定: なし"
+	}
+	lines := []string{
+		"現在のParty設定:",
+		fmt.Sprintf("- ホスト: <@%s>", hostID),
+	}
+	for _, id := range members {
+		lines = append(lines, "- メンバー: <@"+id+">")
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (b *Bot) buildPartyComponents(r *model.Recruitment, hostID string) []discordgo.MessageComponent {
+	candidates := b.partyCandidateSet(r, hostID)
+	options := make([]discordgo.SelectMenuOption, 0, len(candidates))
+	entryName := map[string]string{}
+	for _, e := range r.Entries {
+		entryName[e.UserID] = e.Name
+	}
+	ids := make([]string, 0, len(candidates))
+	for id := range candidates {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	selected := map[string]struct{}{}
+	for _, id := range b.currentPartyMemberSelection(r, hostID) {
+		selected[id] = struct{}{}
+	}
+	for _, id := range ids {
+		label := "<@" + id + ">"
+		if n := entryName[id]; n != "" {
+			label = n
+		}
+		_, isDefault := selected[id]
+		options = append(options, discordgo.SelectMenuOption{
+			Label:   label,
+			Value:   id,
+			Default: isDefault,
+		})
+	}
+	disabled := len(candidates) == 0
+
+	return []discordgo.MessageComponent{
+		discordgo.ActionsRow{
+			Components: []discordgo.MessageComponent{
+				discordgo.SelectMenu{
+					CustomID:    "party_members_select",
+					Placeholder: "Partyメンバーを選択（最大4人）",
+					MinValues:   func() *int { v := 0; return &v }(),
+					MaxValues:   4,
+					Options:     options,
+					Disabled:    disabled,
+				},
+			},
+		},
+		discordgo.ActionsRow{
+			Components: []discordgo.MessageComponent{
+				discordgo.Button{Label: "保存", CustomID: "party_save", Style: discordgo.SuccessButton},
+				discordgo.Button{Label: "解除", CustomID: "party_clear", Style: discordgo.DangerButton},
+				discordgo.Button{Label: "閉じる", CustomID: "party_close", Style: discordgo.SecondaryButton},
+			},
+		},
+	}
+}
+
+func (b *Bot) respondPartyMessage(s *discordgo.Session, i *discordgo.InteractionCreate, r *model.Recruitment, hostID, status string, update bool) error {
+	description := strings.Join([]string{
+		"この募集にだけ有効なParty設定です。",
+		"あなたがホストです。",
+		"Partyメンバーの誰かが抜けた場合、Party全員のエントリーを外します。",
+		"",
+		b.partyStateText(r, hostID),
+	}, "\n")
+	if status != "" {
+		description = status + "\n\n" + description
+	}
+	respType := discordgo.InteractionResponseChannelMessageWithSource
+	if update {
+		respType = discordgo.InteractionResponseUpdateMessage
+	}
+	return s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: respType,
+		Data: &discordgo.InteractionResponseData{
+			Flags: discordgo.MessageFlagsEphemeral,
+			Embeds: []*discordgo.MessageEmbed{
+				{
+					Title:       "👥 Party設定",
+					Description: description,
+					Color:       0x5865F2,
+				},
+			},
+			Components: b.buildPartyComponents(r, hostID),
+		},
+	})
 }
 
 func buildMatchRestartPrompt() string {

--- a/internal/bot/bot_test.go
+++ b/internal/bot/bot_test.go
@@ -208,6 +208,53 @@ func TestBuildRecruitComponentsAssignButtonLabels(t *testing.T) {
 	})
 }
 
+func TestBuildRecruitComponentsContainsPartyButton(t *testing.T) {
+	b := &Bot{}
+	components := b.buildRecruitComponents(&model.Recruitment{}, false)
+	found := false
+	for _, c := range components {
+		row, ok := c.(discordgo.ActionsRow)
+		if !ok {
+			continue
+		}
+		for _, rc := range row.Components {
+			btn, ok := rc.(discordgo.Button)
+			if !ok {
+				continue
+			}
+			if btn.CustomID == "party_open" && btn.Label == "👥 Party設定" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("party button should exist in recruit components")
+	}
+}
+
+func TestRecruitParticipantListIncludesPartyLabels(t *testing.T) {
+	r := &model.Recruitment{
+		Entries: []model.Entry{
+			{UserID: "host", Name: "host"},
+			{UserID: "member", Name: "member"},
+			{UserID: "solo", Name: "solo"},
+		},
+		Parties: map[string][]string{
+			"host": {"member"},
+		},
+	}
+	got := recruitParticipantList(r)
+	if !strings.Contains(got, "<@host> - Party1 ホスト") {
+		t.Fatalf("party host label missing: %s", got)
+	}
+	if !strings.Contains(got, "<@member> - Party1 メンバー") {
+		t.Fatalf("party member label missing: %s", got)
+	}
+	if !strings.Contains(got, "<@solo>") {
+		t.Fatalf("solo entry should remain normal: %s", got)
+	}
+}
+
 func TestTryStartAssignGuardsDuplicateExecution(t *testing.T) {
 	rankData, err := model.LoadEmbeddedRankData()
 	if err != nil {

--- a/internal/model/recruitment.go
+++ b/internal/model/recruitment.go
@@ -19,6 +19,7 @@ type ScoredPlayer struct {
 
 type Recruitment struct {
 	Entries          []Entry
+	Parties          map[string][]string // hostUserID -> member userIDs (hostを除く)
 	RankData         RankDataFile
 	OrganizerID      string // 発案者の Discord UserID
 	MessageID        string // Discord メッセージID（Embed 更新用）
@@ -30,7 +31,7 @@ type Recruitment struct {
 }
 
 func NewRecruitment(rankData RankDataFile) *Recruitment {
-	return &Recruitment{Entries: []Entry{}, RankData: rankData}
+	return &Recruitment{Entries: []Entry{}, Parties: make(map[string][]string), RankData: rankData}
 }
 
 func (r *Recruitment) AddEntry(userID, name string) bool {
@@ -48,10 +49,87 @@ func (r *Recruitment) RemoveEntry(userID string) bool {
 	for i, e := range r.Entries {
 		if e.UserID == userID {
 			r.Entries = append(r.Entries[:i], r.Entries[i+1:]...)
+			return r.removeEntryWithPartyCascade(userID)
+		}
+	}
+	return false
+}
+
+func (r *Recruitment) removeEntryWithPartyCascade(userID string) bool {
+	hostID, members, found := r.findPartyByMember(userID)
+	if !found {
+		return true
+	}
+
+	targetIDs := append([]string{hostID}, members...)
+	for _, id := range targetIDs {
+		if id == userID {
+			continue
+		}
+		for i := 0; i < len(r.Entries); i++ {
+			if r.Entries[i].UserID == id {
+				r.Entries = append(r.Entries[:i], r.Entries[i+1:]...)
+				i--
+			}
+		}
+	}
+	delete(r.Parties, hostID)
+	return true
+}
+
+func (r *Recruitment) SetParty(hostID string, members []string) {
+	if r.Parties == nil {
+		r.Parties = make(map[string][]string)
+	}
+	cleaned := make([]string, 0, len(members))
+	seen := map[string]struct{}{}
+	for _, id := range members {
+		if id == "" || id == hostID {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		cleaned = append(cleaned, id)
+	}
+	if len(cleaned) == 0 {
+		delete(r.Parties, hostID)
+		return
+	}
+	r.Parties[hostID] = cleaned
+}
+
+func (r *Recruitment) ClearParty(hostID string) {
+	delete(r.Parties, hostID)
+}
+
+func (r *Recruitment) IsEntered(userID string) bool {
+	for _, e := range r.Entries {
+		if e.UserID == userID {
 			return true
 		}
 	}
 	return false
+}
+
+func (r *Recruitment) findPartyByMember(userID string) (string, []string, bool) {
+	for hostID, members := range r.Parties {
+		if hostID == userID {
+			return hostID, append([]string{}, members...), true
+		}
+		for _, member := range members {
+			if member == userID {
+				return hostID, append([]string{}, members...), true
+			}
+		}
+	}
+	return "", nil, false
+}
+
+func (r *Recruitment) FindPartyHostOf(userID string) (string, bool) {
+	hostID, _, found := r.findPartyByMember(userID)
+	return hostID, found
 }
 
 func (r *Recruitment) CalculatePlayerScore(highestRank Rank) float64 {
@@ -78,70 +156,253 @@ func (r *Recruitment) MakeTeamsWithRemainder(players []ScoredPlayer) ([][]Scored
 	if len(players) < 10 {
 		return nil, nil
 	}
-	target := len(players) / 5 * 5
+	groups := r.buildPartyGroups(players)
+	selected, remainder := selectGroupedPlayers(groups)
+	if len(selected) < 10 {
+		return nil, nil
+	}
 
-	shuffled := append([]ScoredPlayer(nil), players...)
-	rand.Shuffle(len(shuffled), func(i, j int) { shuffled[i], shuffled[j] = shuffled[j], shuffled[i] })
-	remainder := append([]ScoredPlayer(nil), shuffled[target:]...)
-	shuffled = shuffled[:target]
-
-	sort.Slice(shuffled, func(i, j int) bool { return shuffled[i].Score > shuffled[j].Score })
-	return r.balancedScoreTeams(shuffled), remainder
+	sort.Slice(selected, func(i, j int) bool { return selected[i].Score > selected[j].Score })
+	teams := r.balancedScoreTeams(selected)
+	if teams == nil {
+		return nil, nil
+	}
+	return teams, remainder
 }
 
 func (r *Recruitment) balancedScoreTeams(players []ScoredPlayer) [][]ScoredPlayer {
+	grouped := r.buildPartyGroups(players)
+	if len(grouped) == 0 {
+		return nil
+	}
 	teamCount := len(players) / 5
+	if !canPackPartyGroups(grouped, teamCount) {
+		return nil
+	}
+
 	var best [][]ScoredPlayer
 	bestVariance := math.MaxFloat64
-
-	for range 20 {
-		p := append([]ScoredPlayer(nil), players...)
-		highEnd := len(p) / 3
-		midEnd := highEnd * 2
-		high := append([]ScoredPlayer(nil), p[:highEnd]...)
-		mid := append([]ScoredPlayer(nil), p[highEnd:midEnd]...)
-		low := append([]ScoredPlayer(nil), p[midEnd:]...)
-
-		rand.Shuffle(len(high), func(i, j int) { high[i], high[j] = high[j], high[i] })
-		rand.Shuffle(len(mid), func(i, j int) { mid[i], mid[j] = mid[j], mid[i] })
-		rand.Shuffle(len(low), func(i, j int) { low[i], low[j] = low[j], low[i] })
-
-		teams := make([][]ScoredPlayer, teamCount)
-		for i := 0; i < teamCount; i++ {
-			highCount := min(rand.Intn(2)+1, len(high))
-			for range highCount {
-				teams[i] = append(teams[i], high[len(high)-1])
-				high = high[:len(high)-1]
-			}
-			midCount := min(2, len(mid))
-			for range midCount {
-				teams[i] = append(teams[i], mid[len(mid)-1])
-				mid = mid[:len(mid)-1]
-			}
-			for len(teams[i]) < 5 && len(low) > 0 {
-				teams[i] = append(teams[i], low[len(low)-1])
-				low = low[:len(low)-1]
-			}
+	for range 200 {
+		teams, ok := buildPackedTeamsTrial(grouped, teamCount)
+		if !ok {
+			continue
 		}
-
-		remaining := append(append(high, mid...), low...)
-		for _, pl := range remaining {
-			for i := range teams {
-				if len(teams[i]) < 5 {
-					teams[i] = append(teams[i], pl)
-					break
-				}
-			}
-		}
-
 		variance := teamScoreVariance(teams)
 		if variance < bestVariance {
 			bestVariance = variance
 			best = teams
 		}
 	}
-
 	return best
+}
+
+type playerGroup struct {
+	Players []ScoredPlayer
+}
+
+func (r *Recruitment) buildPartyGroups(players []ScoredPlayer) []playerGroup {
+	playerByID := make(map[string]ScoredPlayer, len(players))
+	for _, p := range players {
+		playerByID[p.ID] = p
+	}
+	used := make(map[string]bool, len(players))
+	groups := make([]playerGroup, 0, len(players))
+	for hostID, members := range r.Parties {
+		if used[hostID] {
+			continue
+		}
+		host, ok := playerByID[hostID]
+		if !ok {
+			continue
+		}
+		groupPlayers := []ScoredPlayer{host}
+		used[hostID] = true
+		valid := true
+		for _, memberID := range members {
+			member, ok := playerByID[memberID]
+			if !ok {
+				valid = false
+				break
+			}
+			groupPlayers = append(groupPlayers, member)
+		}
+		if !valid || len(groupPlayers) > 5 {
+			continue
+		}
+		for _, p := range groupPlayers[1:] {
+			used[p.ID] = true
+		}
+		groups = append(groups, playerGroup{Players: groupPlayers})
+	}
+
+	for _, p := range players {
+		if used[p.ID] {
+			continue
+		}
+		groups = append(groups, playerGroup{Players: []ScoredPlayer{p}})
+	}
+	return groups
+}
+
+func selectGroupedPlayers(groups []playerGroup) ([]ScoredPlayer, []ScoredPlayer) {
+	if len(groups) == 0 {
+		return nil, nil
+	}
+	bestSelection := make([]bool, len(groups))
+	bestTotal := -1
+	groupCount := len(groups)
+	if groupCount <= 20 {
+		limit := 1 << groupCount
+		for mask := 0; mask < limit; mask++ {
+			selection := make([]bool, len(groups))
+			total := 0
+			for idx := range groups {
+				if mask&(1<<idx) == 0 {
+					continue
+				}
+				selection[idx] = true
+				total += len(groups[idx].Players)
+			}
+			if total < 10 || total%5 != 0 {
+				continue
+			}
+			if total > bestTotal {
+				bestTotal = total
+				bestSelection = selection
+			}
+		}
+	} else {
+		for range 6000 {
+			selection := make([]bool, len(groups))
+			total := 0
+			for idx := range groups {
+				if rand.Intn(2) == 0 {
+					continue
+				}
+				selection[idx] = true
+				total += len(groups[idx].Players)
+			}
+			if total < 10 || total%5 != 0 {
+				continue
+			}
+			if total > bestTotal {
+				bestTotal = total
+				bestSelection = selection
+			}
+		}
+	}
+
+	if bestTotal < 10 {
+		return nil, nil
+	}
+
+	selected := make([]ScoredPlayer, 0, bestTotal)
+	remainder := make([]ScoredPlayer, 0)
+	for idx, group := range groups {
+		if !bestSelection[idx] {
+			remainder = append(remainder, group.Players...)
+			continue
+		}
+		selected = append(selected, group.Players...)
+	}
+	return selected, remainder
+}
+
+func canPackPartyGroups(groups []playerGroup, teamCount int) bool {
+	sizes := make([]int, len(groups))
+	for i, g := range groups {
+		sizes[i] = len(g.Players)
+	}
+	sort.Slice(sizes, func(i, j int) bool { return sizes[i] > sizes[j] })
+	caps := make([]int, teamCount)
+	for i := range caps {
+		caps[i] = 5
+	}
+	var dfs func(idx int) bool
+	dfs = func(idx int) bool {
+		if idx == len(sizes) {
+			for _, cap := range caps {
+				if cap != 0 {
+					return false
+				}
+			}
+			return true
+		}
+		seen := map[int]struct{}{}
+		for i := range caps {
+			if caps[i] < sizes[idx] {
+				continue
+			}
+			if _, ok := seen[caps[i]]; ok {
+				continue
+			}
+			seen[caps[i]] = struct{}{}
+			caps[i] -= sizes[idx]
+			if dfs(idx + 1) {
+				return true
+			}
+			caps[i] += sizes[idx]
+		}
+		return false
+	}
+	return dfs(0)
+}
+
+func buildPackedTeamsTrial(groups []playerGroup, teamCount int) ([][]ScoredPlayer, bool) {
+	teams := make([][]ScoredPlayer, teamCount)
+	teamSizes := make([]int, teamCount)
+	teamScores := make([]float64, teamCount)
+	shuffled := append([]playerGroup(nil), groups...)
+	rand.Shuffle(len(shuffled), func(i, j int) { shuffled[i], shuffled[j] = shuffled[j], shuffled[i] })
+	sort.Slice(shuffled, func(i, j int) bool { return len(shuffled[i].Players) > len(shuffled[j].Players) })
+	for _, group := range shuffled {
+		size := len(group.Players)
+		candidates := make([]int, 0, teamCount)
+		for idx := range teams {
+			if teamSizes[idx]+size <= 5 {
+				candidates = append(candidates, idx)
+			}
+		}
+		if len(candidates) == 0 {
+			return nil, false
+		}
+		bestTeam := candidates[0]
+		bestGap := math.MaxFloat64
+		groupAvg := teamAverage(group.Players)
+		for _, idx := range candidates {
+			avg := teamScores[idx]
+			if teamSizes[idx] > 0 {
+				avg /= float64(teamSizes[idx])
+			}
+			gap := math.Abs(avg - groupAvg)
+			if gap < bestGap {
+				bestGap = gap
+				bestTeam = idx
+			}
+		}
+		teams[bestTeam] = append(teams[bestTeam], group.Players...)
+		teamSizes[bestTeam] += size
+		for _, p := range group.Players {
+			teamScores[bestTeam] += p.Score
+		}
+	}
+	for _, s := range teamSizes {
+		if s != 5 {
+			return nil, false
+		}
+	}
+	return teams, true
+}
+
+func teamAverage(players []ScoredPlayer) float64 {
+	if len(players) == 0 {
+		return 0
+	}
+	total := 0.0
+	for _, p := range players {
+		total += p.Score
+	}
+	return total / float64(len(players))
 }
 
 func teamScoreVariance(teams [][]ScoredPlayer) float64 {

--- a/internal/model/recruitment_test.go
+++ b/internal/model/recruitment_test.go
@@ -141,3 +141,48 @@ func TestRemoveEntry_notExisting(t *testing.T) {
 		t.Errorf("len(Entries) = %d, want 1", len(r.Entries))
 	}
 }
+
+func TestPartyCascadeOnRemoveEntry(t *testing.T) {
+	r := NewRecruitment(testRankData())
+	r.AddEntry("host", "Host")
+	r.AddEntry("m1", "M1")
+	r.AddEntry("solo", "Solo")
+	r.SetParty("host", []string{"m1"})
+
+	if !r.RemoveEntry("m1") {
+		t.Fatalf("RemoveEntry should succeed")
+	}
+	if r.IsEntered("host") {
+		t.Fatalf("host should also be removed by party cascade")
+	}
+	if !r.IsEntered("solo") {
+		t.Fatalf("unrelated solo entry should remain")
+	}
+	if _, ok := r.FindPartyHostOf("host"); ok {
+		t.Fatalf("party should be cleared after cascade")
+	}
+}
+
+func TestMakeTeamsWithPartyConstraint(t *testing.T) {
+	r := NewRecruitment(testRankData())
+	players := []ScoredPlayer{
+		{ID: "a", Score: 2000}, {ID: "b", Score: 1900}, {ID: "c", Score: 1800}, {ID: "d", Score: 1700}, {ID: "e", Score: 1600},
+		{ID: "f", Score: 1500}, {ID: "g", Score: 1400}, {ID: "h", Score: 1300}, {ID: "i", Score: 1200}, {ID: "j", Score: 1100},
+	}
+	r.SetParty("a", []string{"b", "c"})
+
+	teams, _ := r.MakeTeamsWithRemainder(players)
+	if len(teams) == 0 {
+		t.Fatalf("expected team assignment")
+	}
+
+	teamIdx := map[string]int{}
+	for i, team := range teams {
+		for _, p := range team {
+			teamIdx[p.ID] = i
+		}
+	}
+	if teamIdx["a"] != teamIdx["b"] || teamIdx["a"] != teamIdx["c"] {
+		t.Fatalf("party members should stay in the same team")
+	}
+}


### PR DESCRIPTION
### Motivation
- 募集ごとに一時的な Party を持たせ、同じ Party の参加者をチーム振り分けで必ず分割しないようにするためのデモ用機能を追加しました。
- 永続化不要で募集ライフタイムのみ有効とする仕様を反映するため、募集単位の状態管理とUI拡張が必要でした。

### Description
- `Recruitment` に `Parties` を追加して Party 定義（ホスト -> メンバー一覧）と逆引き関数を実装し、`SetParty`/`ClearParty`/`FindPartyHostOf`/`IsEntered` を追加しました（`internal/model/recruitment.go`）。
- エントリー取り消し時に Party に所属する誰かが抜けた場合は Party 全員を強制的にエントリー解除して Party を削除するカスケード処理を `RemoveEntry` に統合しました（強めの挙動）。
- チーム振り分けロジックを Party 単位で扱うように拡張し、Party を分割せずに詰められない場合は振り分け失敗となる制約を導入しました（グルーピング・選択・パッキング検査・パッキング試行アルゴリズムを実装）。
- 募集メッセージUIに `👥 Party設定` ボタンを追加し、エフェメラルでの設定フロー（ユーザー選択プルダウン・保存・解除・閉じる）と各種バリデーション（未エントリー拒否 / 自分除外 / ダミー除外 / 別Party所属除外 / 最大5人制）を実装しました（`internal/bot/bot.go`）。
- 参加者一覧表示を Party 単位で見やすく並べ替え、各行に `PartyN ホスト/メンバー` の注記を付ける表示変更を行いました（表示用ラベルは仮番号で募集更新時に再採番可能）。

### Testing
- 新規/変更コードに対してユニットテストを追加・実行し、すべて成功しました（`go test ./...` 成功）。
- 実行した主要コマンドは `go test ./internal/model -run TestPartyCascadeOnRemoveEntry`、`go test ./internal/bot -run 'TestBuildRecruitComponentsContainsPartyButton|TestRecruitParticipantListIncludesPartyLabels'`、およびフルテスト `go test ./...` で、いずれも成功しています。 
- 追加した自動テストには `TestPartyCascadeOnRemoveEntry`、`TestMakeTeamsWithPartyConstraint`、`TestBuildRecruitComponentsContainsPartyButton`、`TestRecruitParticipantListIncludesPartyLabels` が含まれています。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d679e58ba08321aca7bdb3d7edffb5)